### PR TITLE
fix login button so hover and active styling is right closes #34

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -15,6 +15,12 @@
 
 .navbar-default .navbar-nav > .active > a {
   background-color: transparent;
+  color: white;
+}
+
+.navbar-default .navbar-nav > .active > a:hover {
+  background-color: transparent;
+  color: white;
 }
 
 .navbar-default .navbar-nav > li > a {


### PR DESCRIPTION
The login button was styling wrong when it was active so we fixed that. now it stays white with a transparent background.
