### PR TITLE
fixed the skipped image test that it can be associated with an event closes #81

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -8,10 +8,6 @@ FactoryGirl.define do
     "title#{n}"
   end
 
-  sequence :display_name do |n|
-    "display name#{n}"
-  end
-
   factory :admin do
     full_name "Yolo Ono"
     email "admin@admin.com"
@@ -24,7 +20,7 @@ FactoryGirl.define do
     email "john@bobo.com"
     password "test"
     password_confirmation "test"
-    display_name
+    display_name "john-smithy"
   end
 
   factory :image do

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe Image, type: :model do
     expect(item).not_to be_valid
   end
 
-  xit "can be associated with an event" do
-    image1 = create(:image)
-    event = create(:event, image_id: image1.id)
-
-    expect(event.image.title).to eq(image1.title)
+  it "can be associated with an event" do
+    image = create(:image)
+    event = build(:event, image_id: image.id)
+    
+    expect(event.image.title).to eq(image.title)
   end
 end


### PR DESCRIPTION
I fixed the image test that it can be associated with an event. 

Also when I ran spec two of other user tests were failing because it was taking factory girl generated display name in users...I couldn't think what will be the best approach, to keep the generated display name as slug or the previous way. 
