### PR TITLE
Fix redirect after register user during checkout

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 class UsersController < ApplicationController
   def new
-    session[:return_to] ||= request.referer if request.original_url != login_for_cart_url
+    if request.original_url != login_for_cart_url && request.original_url != new_user_url
+      session[:return_to] ||= request.referer
+    end
     @user = User.new
   end
 


### PR DESCRIPTION
Now, when a guest clicks checkout and creates a new account from the login page it'll redirect to the order review page. 
