### PR TITLE
Fix redirect after login and sign up closes #121

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,10 +17,8 @@ class ApplicationController < ActionController::Base
   def redirect_after_login
     if session[:admin] == true
       redirect_to admin_path
-    elsif session[:return_to]
-      redirect_to session[:return_to]
     else
-      redirect_to new_order_path
+      redirect_to session[:return_to]
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,9 @@
 class SessionsController < ApplicationController
   def new
-    if request.original_url != login_for_cart_url
-      session[:return_to] ||= request.referer
+    if request.path != login_for_cart_path
+      session[:return_to] = request.referer
+    else
+      session[:return_to] = new_order_path
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find_by(slug: params[:slug])
+    @user = User.find_by(display_name: params[:display_name])
     @items = Item.active.available.where.not(id: session[:cart]).where(user_id: @user.id)
     @user_events = @user.group_events
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,9 @@
 class UsersController < ApplicationController
   def new
-    if request.original_url != login_for_cart_url && request.original_url != new_user_url
+    if request.path != login_for_cart_url
       session[:return_to] ||= request.referer
+    else
+      session[:return_to] ||= new_order_path
     end
     @user = User.new
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -36,7 +36,7 @@ class Item < ActiveRecord::Base
   end
 
   def seller
-    user.slug
+    user.display_name
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,6 @@ class User < ActiveRecord::Base
   has_many :orders
   has_many :order_items, through: :orders
 
-  before_validation :generate_slug
-
   validates :full_name, presence: true, length: { in: 5..100 },
   format: { with: /\A[a-z ,.'-]+\z/i, }
   validates :email, presence: true, length: { maximum: 255 },
@@ -18,10 +16,6 @@ class User < ActiveRecord::Base
 
   def admin?
     false
-  end
-
-  def generate_slug
-    self.slug = display_name.parameterize unless display_name.nil?
   end
 
   def group_events

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 
   get "/admin" => "admin#index"
 
-  scope "/:slug", as: "user" do
+  scope "/:display_name", as: "user" do
     get "/store" => "users#show", as: "store"
   end
 

--- a/db/migrate/20150222011013_remove_slug_from_users.rb
+++ b/db/migrate/20150222011013_remove_slug_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveSlugFromUsers < ActiveRecord::Migration
+  def change
+    remove_column :users, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150220214523) do
+ActiveRecord::Schema.define(version: 20150222011013) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,7 +104,6 @@ ActiveRecord::Schema.define(version: 20150220214523) do
     t.string   "display_name"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
-    t.string   "slug"
   end
 
   create_table "venues", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -8,6 +8,14 @@ FactoryGirl.define do
     "title#{n}"
   end
 
+  sequence :display_name do |n|
+    "display#{n}"
+  end
+
+  sequence :email do |n|
+    "email#{n}@gmail.com"
+  end
+
   factory :admin do
     full_name "Yolo Ono"
     email "admin@admin.com"
@@ -17,10 +25,10 @@ FactoryGirl.define do
 
   factory :user do
     full_name "John Bob Smith"
-    email "john@bobo.com"
+    email
     password "test"
     password_confirmation "test"
-    display_name "johnsmithy"
+    display_name
   end
 
   factory :image do

--- a/spec/integration/guest_view_spec.rb
+++ b/spec/integration/guest_view_spec.rb
@@ -212,7 +212,7 @@ describe "the guest view", type: :feature do
       ticket.event_id = event.id
       user.items << ticket
 
-      visit user_store_path(user.slug)
+      visit user_store_path(user.display_name)
       expect(page).to have_content("$5.00")
       expect(page).to have_content("John Bob Smith")
     end
@@ -223,7 +223,7 @@ describe "the guest view", type: :feature do
       user = create(:user)
       item = create(:item, user_id: user.id, event_id: event.id)
 
-      visit user_store_path(user.slug)
+      visit user_store_path(user.display_name)
 
       expect(page).to_not have_content(event.title)
       expect(page).to_not have_content(event.venue.name)

--- a/spec/integration/user_views_spec.rb
+++ b/spec/integration/user_views_spec.rb
@@ -130,14 +130,13 @@ describe "the user" do
 
   it "is redirected to the order summary after login from checkout" do
     event = create(:event)
-    item = create(:item, event: event)
-    user = create(:user)
+    seller = create(:user)
+    item = create(:item, event: event, user_id: seller.id)
+    user= create(:user)
     visit event_path(event)
-    save_and_open_page
     click_button("Add to cart")
 
     visit cart_path
-    save_and_open_page
     click_link("Checkout")
     fill_in "session[email]", with: user.email
     fill_in "session[password]", with: user.password
@@ -147,9 +146,14 @@ describe "the user" do
   end
 
   it "is redirected to review order when login from checkout" do
-    user = build(:user)
-    visit cart_path
+    event = create(:event)
+    seller = create(:user)
+    item = create(:item, event: event, user_id: seller.id)
+    user= build(:user)
+    visit event_path(event)
+    click_button("Add to cart")
 
+    visit cart_path
     click_link("Checkout")
     click_link("here")
     fill_in "user[full_name]", with: user.full_name

--- a/spec/integration/user_views_spec.rb
+++ b/spec/integration/user_views_spec.rb
@@ -85,7 +85,7 @@ describe "the user" do
     expect(page).to have_content("Successfully logged in")
   end
 
-  xit "is redirected back to the page it came from" do
+  it "is redirected back to the page it came from after sign up from nav bar" do
     user = build(:user)
 
     visit tickets_path
@@ -98,6 +98,68 @@ describe "the user" do
     click_button("Create my account!")
 
     expect(current_path).to eq tickets_path
+  end
+
+  it "is redirected back to the page it came from after login from nav bar" do
+    user = create(:user)
+
+    visit tickets_path
+    click_link("Login")
+    fill_in "session[email]", with: user.email
+    fill_in "session[password]", with: user.password
+    click_button("Log in")
+
+    expect(current_path).to eq tickets_path
+  end
+
+  it "is redirected back to the page it came from after sign up through login" do
+    user = build(:user)
+
+    visit tickets_path
+    click_link("Login")
+    click_link("here")
+    fill_in "user[full_name]", with: user.full_name
+    fill_in "user[display_name]", with: user.display_name
+    fill_in "user[email]", with: user.email
+    fill_in "user[password]", with: user.password
+    fill_in "user[password_confirmation]", with: user.password
+    click_button("Create my account!")
+
+    expect(current_path).to eq tickets_path
+  end
+
+  it "is redirected to the order summary after login from checkout" do
+    event = create(:event)
+    item = create(:item, event: event)
+    user = create(:user)
+    visit event_path(event)
+    save_and_open_page
+    click_button("Add to cart")
+
+    visit cart_path
+    save_and_open_page
+    click_link("Checkout")
+    fill_in "session[email]", with: user.email
+    fill_in "session[password]", with: user.password
+    click_button("Log in")
+
+    expect(current_path).to eq new_order_path
+  end
+
+  it "is redirected to review order when login from checkout" do
+    user = build(:user)
+    visit cart_path
+
+    click_link("Checkout")
+    click_link("here")
+    fill_in "user[full_name]", with: user.full_name
+    fill_in "user[display_name]", with: user.display_name
+    fill_in "user[email]", with: user.email
+    fill_in "user[password]", with: user.password
+    fill_in "user[password_confirmation]", with: user.password
+    click_button("Create my account!")
+
+    expect(current_path).to eq new_order_path
   end
 
   it "sees a Logout button instead of Login " do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -38,11 +38,6 @@ describe User, { type: "model" } do
     expect(new_user).not_to be_valid
   end
 
-  it "generates a slug when it is created" do
-    user = create(:user)
-    expect(user.slug).to eq(user.display_name.parameterize)
-  end
-
   it "only takes a correctly formated email" do
     user = build(:user, email: "john")
 


### PR DESCRIPTION
Fixed redirect after login/sign up and added some tests to try to cover all of the scenarios of when a user would log in. 

Updated the user store path to user the user's display_name instead of making a slug since the dispaly_name validations now make sure that the user's store paths will be unique

update factories so that you can make multiple users and they will pass validations
